### PR TITLE
Fix Render build with explicit dependency versions

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+- type: web
+  name: btc-alt-rebalancer
+  env: python
+  plan: free
+  buildCommand: pip install -r requirements.txt
+  startCommand: streamlit run app.py --server.port $PORT --server.address 0.0.0.0
+  autoDeploy: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
-streamlit
-pandas
+requests==2.31.0
+streamlit==1.32.0
+pandas==2.2.1


### PR DESCRIPTION
## Summary
- pin dependencies to known versions
- add `render.yaml` for Render deployment configuration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683d6d2a15ec8333909153e9cc93cd97